### PR TITLE
Testing fix

### DIFF
--- a/core/lib/workarea/version.rb
+++ b/core/lib/workarea/version.rb
@@ -2,7 +2,7 @@ module Workarea
   module VERSION
     MAJOR = 3
     MINOR = 7
-    PATCH = 0
+    PATCH = 1
     STRING = [MAJOR, MINOR, PATCH].compact.join('.')
 
     module MONGODB

--- a/testing/workarea-testing.gemspec
+++ b/testing/workarea-testing.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'teaspoon', '~> 1.2.0'
   s.add_dependency 'teaspoon-mocha', '~> 2.3.3'
   s.add_dependency 'mocha', '~> 1.3.0'
-  s.add_dependency 'selenium-webdriver', '~> 4.0'
+  s.add_dependency 'selenium-webdriver', '~> 4.10.0'
   s.add_dependency 'webdrivers', '~> 5.0'
   s.add_dependency 'capybara-chromedriver-logger', '~> 0.2.1'
   s.add_dependency 'minitest-retry', '~> 0.1.5'


### PR DESCRIPTION
This PR fixes the chrome driver testing bug by pinning the selenium-webdriver gem to the last version that works properly with the webdrivers gem. It also bumps the patch version number to reflect the bug fix.