### PR TITLE
Enable zeitwerk

### DIFF
--- a/core/config/initializers/00_configuration.rb
+++ b/core/config/initializers/00_configuration.rb
@@ -212,7 +212,7 @@ Workarea::Configuration.define_fields do
     ).squish.html_safe
 
     field :site_key, name: 'v3 Site Key', type: :string, required: false
-    field :secret_key, name: 'v3 Secret Key', type: :string, required: false, encrypted: true
+    field :secret_key, name: 'v3 Secret Key', type: :string, required: false
     field :minimum_score,
       name: 'Minimum Score',
       type: :float,
@@ -235,7 +235,7 @@ Workarea::Configuration.define_fields do
     ).squish.html_safe
 
     field :site_key, name: 'v2 Site Key', type: :string, required: false
-    field :secret_key, name: 'v2 Secret Key', type: :string, required: false, encrypted: true
+    field :secret_key, name: 'v2 Secret Key', type: :string, required: false
   end
 
   fieldset :security, namespaced: false do

--- a/core/lib/workarea/version.rb
+++ b/core/lib/workarea/version.rb
@@ -1,7 +1,7 @@
 module Workarea
   module VERSION
     MAJOR = 3
-    MINOR = 7
+    MINOR = 8
     PATCH = 0
     STRING = [MAJOR, MINOR, PATCH].compact.join('.')
 

--- a/core/workarea-core.gemspec
+++ b/core/workarea-core.gemspec
@@ -76,7 +76,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'minitest', '~> 5.14.0'
   s.add_dependency 'countries', '~> 3.0.0'
   s.add_dependency 'waypoints_rails', '~> 4.0.1'
-  s.add_dependency 'rails-decorators', '0.1.4'
+  s.add_dependency 'rails-decorators', '>= 0.1.4'
   s.add_dependency 'icalendar', '~> 2.7.0'
   s.add_dependency 'premailer-rails', '~> 1.11.0'
   s.add_dependency 'json-streamer', '~> 2.1.0'

--- a/core/workarea-core.gemspec
+++ b/core/workarea-core.gemspec
@@ -76,7 +76,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'minitest', '~> 5.14.0'
   s.add_dependency 'countries', '~> 3.0.0'
   s.add_dependency 'waypoints_rails', '~> 4.0.1'
-  s.add_dependency 'rails-decorators', '>= 0.1.4'
+  s.add_dependency 'rails-decorators', '~> 1.0.0'
   s.add_dependency 'icalendar', '~> 2.7.0'
   s.add_dependency 'premailer-rails', '~> 1.11.0'
   s.add_dependency 'json-streamer', '~> 2.1.0'


### PR DESCRIPTION
**Changes**
- Bump minimum rails-decorators version (for Zeitwerk)
- Prevent Recaptcha fields from being mistaken as password fields
- Bump gem version