### PR TITLE
Ruby 3.3 for version tagging

### DIFF
--- a/admin/app/helpers/workarea/admin/navigation_helper.rb
+++ b/admin/app/helpers/workarea/admin/navigation_helper.rb
@@ -11,15 +11,15 @@ module Workarea
 
       def todays_orders_path
         orders_path(
-          placed_at_greater_than: Time.current.to_s(:date_only),
-          placed_at_less_than: Time.current.to_s(:date_only)
+          placed_at_greater_than: Time.current.to_fs(:date_only),
+          placed_at_less_than: Time.current.to_fs(:date_only)
         )
       end
 
       def yesterdays_orders_path
         orders_path(
-          placed_at_greater_than: 1.day.ago.to_s(:date_only),
-          placed_at_less_than: 1.day.ago.to_s(:date_only)
+          placed_at_greater_than: 1.day.ago.to_fs(:date_only),
+          placed_at_less_than: 1.day.ago.to_fs(:date_only)
         )
       end
 
@@ -34,8 +34,8 @@ module Workarea
       # TODO remove in v3.6, no longer used
       def todays_signups_path
         users_path(
-          created_at_greater_than: Time.current.to_s(:date_only),
-          created_at_less_than: Time.current.to_s(:date_only)
+          created_at_greater_than: Time.current.to_fs(:date_only),
+          created_at_less_than: Time.current.to_fs(:date_only)
         )
       end
 

--- a/core/app/helpers/workarea/application_helper.rb
+++ b/core/app/helpers/workarea/application_helper.rb
@@ -4,7 +4,7 @@ module Workarea
       host = Rails.application.config.action_controller.asset_host
       source = image_url(product_image_path(image, job))
       return source if host.blank?
-      return source if ActiveModel::Type::Boolean.new.cast(source =~ /^(http|\/\/)/)
+      return source if source.starts_with?('//', 'http')
 
       # These shenanigans are here to work around a Rails problem where the
       # configured asset host isn't being used if it's a proc. We use a proc in

--- a/core/app/helpers/workarea/application_helper.rb
+++ b/core/app/helpers/workarea/application_helper.rb
@@ -3,7 +3,8 @@ module Workarea
     def product_image_url(image, job)
       host = Rails.application.config.action_controller.asset_host
       source = image_url(product_image_path(image, job))
-      return source if host.blank? || source =~ /^(http|\/\/)/
+      return source if host.blank?
+      return source if ActiveModel::Type::Boolean.new.cast(source =~ /^(http|\/\/)/)
 
       # These shenanigans are here to work around a Rails problem where the
       # configured asset host isn't being used if it's a proc. We use a proc in

--- a/core/app/models/workarea/content.rb
+++ b/core/app/models/workarea/content.rb
@@ -59,7 +59,6 @@ module Workarea
     # @deprecated Use `Workarea.define_content_block_types` instead.
     class << self
       def define_block_types(&block)
-        require_dependency 'workarea/content/block_type_definition'
         definition = BlockTypeDefinition.new
         definition.instance_eval(&block)
       end

--- a/core/app/models/workarea/release/changeset.rb
+++ b/core/app/models/workarea/release/changeset.rb
@@ -1,6 +1,3 @@
-# This fixes Release::Changes == Mongoid::AuditLog::Changes in development
-require_dependency 'workarea/release/changes'
-
 module Workarea
   class Release
     class Changeset

--- a/core/app/models/workarea/search/admin/order.rb
+++ b/core/app/models/workarea/search/admin/order.rb
@@ -18,7 +18,7 @@ module Workarea
 
         def jump_to_text
           if model.placed?
-            "#{model.id} - Placed @ #{model.placed_at.to_s(:short)}"
+            "#{model.id} - Placed @ #{model.placed_at.to_fs(:short)}"
           else
             "#{model.id} - #{model.status.to_s.titleize}"
           end

--- a/core/app/models/workarea/search/storefront/category_query.rb
+++ b/core/app/models/workarea/search/storefront/category_query.rb
@@ -1,6 +1,3 @@
-# For some reason, loading Search::Storefront::Product doesn't get triggered
-require_dependency 'workarea/search/storefront/product'
-
 module Workarea
   module Search
     class Storefront

--- a/core/app/models/workarea/user/password_reset.rb
+++ b/core/app/models/workarea/user/password_reset.rb
@@ -28,8 +28,8 @@ module Workarea
         if user.update_attributes(password: new_password)
           destroy
         else
-          user.errors.each do |attribute, error|
-            errors.add(attribute, error)
+          user.errors.each do |error|
+            errors.add(error.attribute, error.message)
           end
           false
         end

--- a/core/config/initializers/03_js_routes.rb
+++ b/core/config/initializers/03_js_routes.rb
@@ -1,3 +1,5 @@
 JsRoutes.setup do |config|
   config.camel_case = true
+  config.module_type = nil
+  config.namespace = "Routes"
 end

--- a/core/config/initializers/05_scheduled_jobs.rb
+++ b/core/config/initializers/05_scheduled_jobs.rb
@@ -31,7 +31,7 @@ unless Workarea.skip_services?
     Sidekiq::Cron::Job.create(
       name: 'Workarea::KeepProductIndexFresh',
       klass: 'Workarea::KeepProductIndexFresh',
-      cron: "5,20,35,50 * * * * #{Time.zone.tzinfo.identifier}",
+      cron: "35 * * * * #{Time.zone.tzinfo.identifier}",
       queue: 'low'
     )
 

--- a/core/config/initializers/10_rack_middleware.rb
+++ b/core/config/initializers/10_rack_middleware.rb
@@ -1,3 +1,6 @@
+require "#{Workarea::Core::Engine.root}/app/middleware/workarea/enforce_host_middleware"
+require "#{Workarea::Core::Engine.root}/app/middleware/workarea/application_middleware"
+
 app = Rails.application
 app.config.middleware.use(Mongoid::QueryCache::Middleware)
 app.config.middleware.use(Workarea::Elasticsearch::QueryCache::Middleware)
@@ -23,4 +26,7 @@ Rails.application.config.middleware.insert_after(
 
 app.config.middleware.use Workarea::EnforceHostMiddleware
 app.config.middleware.insert(0, Workarea::ApplicationMiddleware)
-app.config.middleware.insert(0, Workarea::StripHttpCachingMiddleware) if Rails.env.test?
+if Rails.env.test?
+  require 'workarea/strip_http_caching_middleware'
+  app.config.middleware.insert(0, Workarea::StripHttpCachingMiddleware) 
+end

--- a/core/lib/generators/workarea/decorator/decorator_generator.rb
+++ b/core/lib/generators/workarea/decorator/decorator_generator.rb
@@ -32,7 +32,7 @@ module Workarea
     def find_existing_file(source_path)
       workarea_plugin_paths
         .map { |plugin_root| File.join(plugin_root, source_path) }
-        .detect { |path| File.exists?(path) }
+        .detect { |path| File.exist?(path) }
     end
 
     def workarea_plugin_paths

--- a/core/lib/workarea/configuration/sidekiq.rb
+++ b/core/lib/workarea/configuration/sidekiq.rb
@@ -9,6 +9,7 @@ module Workarea
         require "#{Workarea::Core::Engine.root}/app/middleware/workarea/audit_log_client_middleware"
         require "#{Workarea::Core::Engine.root}/app/middleware/workarea/audit_log_server_middleware"
         require "#{Workarea::Core::Engine.root}/app/middleware/workarea/release_server_middleware"
+        require "#{Workarea::Core::Engine.root}/app/workers/sidekiq/callbacks"
 
         unless manually_configured?
           ::Sidekiq.options.merge!(

--- a/core/lib/workarea/configuration/sidekiq.rb
+++ b/core/lib/workarea/configuration/sidekiq.rb
@@ -4,11 +4,11 @@ module Workarea
       extend self
 
       def load
-        require_dependency "#{Workarea::Core::Engine.root}/app/middleware/workarea/i18n_client_middleware"
-        require_dependency "#{Workarea::Core::Engine.root}/app/middleware/workarea/i18n_server_middleware"
-        require_dependency "#{Workarea::Core::Engine.root}/app/middleware/workarea/audit_log_client_middleware"
-        require_dependency "#{Workarea::Core::Engine.root}/app/middleware/workarea/audit_log_server_middleware"
-        require_dependency "#{Workarea::Core::Engine.root}/app/middleware/workarea/release_server_middleware"
+        require "#{Workarea::Core::Engine.root}/app/middleware/workarea/i18n_client_middleware"
+        require "#{Workarea::Core::Engine.root}/app/middleware/workarea/i18n_server_middleware"
+        require "#{Workarea::Core::Engine.root}/app/middleware/workarea/audit_log_client_middleware"
+        require "#{Workarea::Core::Engine.root}/app/middleware/workarea/audit_log_server_middleware"
+        require "#{Workarea::Core::Engine.root}/app/middleware/workarea/release_server_middleware"
 
         unless manually_configured?
           ::Sidekiq.options.merge!(

--- a/core/lib/workarea/core/engine.rb
+++ b/core/lib/workarea/core/engine.rb
@@ -73,17 +73,6 @@ module Workarea
         Workarea::Warnings.check
         Configuration::Session.validate!
       end
-
-      config.to_prepare do
-        # For some reason, app/workers/workarea/bulk_index_products.rb doesn't
-        # get autoloaded. Without this, admin actions like updating product
-        # attributes raises a {NameError} "uninitialized constant BulkIndexProducts".
-        require_dependency 'workarea/bulk_index_products'
-
-        # Fixes a constant error raised in middleware (when doing segmentation)
-        # No idea what the cause is. TODO revisit after Zeitwerk.
-        require_dependency 'workarea/metrics/user'
-      end
     end
   end
 end

--- a/core/lib/workarea/validators/parameter_validator.rb
+++ b/core/lib/workarea/validators/parameter_validator.rb
@@ -1,9 +1,7 @@
 class ParameterValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     unless value =~ /^[\w\-]+$/
-      record.errors[attribute] << <<-eos
-        must contain only alphanumeric, underscore, and hyphen characters
-      eos
+      record.errors.add(attribute, 'must contain only alphanumeric, underscore, and hyphen characters')
     end
   end
 end

--- a/core/lib/workarea/version.rb
+++ b/core/lib/workarea/version.rb
@@ -1,8 +1,8 @@
 module Workarea
   module VERSION
     MAJOR = 3
-    MINOR = 8
-    PATCH = 1
+    MINOR = 9
+    PATCH = 0
     STRING = [MAJOR, MINOR, PATCH].compact.join('.')
 
     module MONGODB

--- a/core/test/workers/workarea/generate_sitemaps_test.rb
+++ b/core/test/workers/workarea/generate_sitemaps_test.rb
@@ -68,7 +68,7 @@ module Workarea
 
     def test_cleans_up_tmp_directory
       GenerateSitemaps.new.perform
-      refute(Dir.exists?(Rails.root.join('tmp', 'sitemaps')))
+      refute(Dir.exist?(Rails.root.join('tmp', 'sitemaps')))
     end
 
     def test_overwrites_existing_sitemap

--- a/core/workarea-core.gemspec
+++ b/core/workarea-core.gemspec
@@ -12,10 +12,10 @@ Gem::Specification.new do |s|
   s.description = "Provides application code, seed data, plugin infrastructure, and other core parts of the Workarea Commerce Platform."
 
   s.files = `git ls-files -- . ':!:data/product_images/*.jpg'`.split("\n")
-  s.required_ruby_version = '>= 2.7.0'
+  s.required_ruby_version = '>= 3.1.0'
 
   s.add_dependency 'bundler', '>= 1.8.0' # 1.8.0 added env variable for secrets
-  s.add_dependency 'rails', '~> 6.1.0'
+  s.add_dependency 'rails', '~> 7.0.0'
   s.add_dependency 'mongoid', '~> 7.5.0'
   s.add_dependency 'bcrypt', '~> 3.1.10'
   s.add_dependency 'money-rails', '~> 1.15.0'

--- a/core/workarea-core.gemspec
+++ b/core/workarea-core.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'sprockets-rails', '~> 3.2.0'
   s.add_dependency 'sprockets', '~> 3.7.2'
   s.add_dependency 'predictor', '~> 2.3.0'
-  s.add_dependency 'js-routes', '2.0.0'
+  s.add_dependency 'js-routes', '2.2.8'
   s.add_dependency 'mongoid-active_merchant', '~> 0.2.0'
   s.add_dependency 'normalize-rails', '~> 8.0.1'
   s.add_dependency 'featurejs_rails', '~> 1.0.1'

--- a/core/workarea-core.gemspec
+++ b/core/workarea-core.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'sprockets-rails', '~> 3.2.0'
   s.add_dependency 'sprockets', '~> 3.7.2'
   s.add_dependency 'predictor', '~> 2.3.0'
-  s.add_dependency 'js-routes', '~> 1.4.0'
+  s.add_dependency 'js-routes', '2.0.0'
   s.add_dependency 'mongoid-active_merchant', '~> 0.2.0'
   s.add_dependency 'normalize-rails', '~> 8.0.1'
   s.add_dependency 'featurejs_rails', '~> 1.0.1'

--- a/storefront/app/view_models/workarea/storefront/product_view_model/cache_key.rb
+++ b/storefront/app/view_models/workarea/storefront/product_view_model/cache_key.rb
@@ -19,7 +19,7 @@ module Workarea
         def product_parts
           [
             @product.send(:model_key), # Mongoid has this as a private method
-            "#{@product.id}-#{@product.updated_at.utc.to_s(:nsec)}"
+            "#{@product.id}-#{@product.updated_at.utc.to_fs(:nsec)}"
           ]
         end
 

--- a/testing/lib/workarea/system_test.rb
+++ b/testing/lib/workarea/system_test.rb
@@ -1,5 +1,4 @@
 require 'capybara/rails'
-require 'webdrivers'
 require 'puma'
 require 'capybara/chromedriver/logger'
 require 'workarea/integration_test'


### PR DESCRIPTION
A housekeeping PR, this one merges changes that we've been running on for a while into master so we can tag a version ahead of updating to Rails 7.1.

**Changes**
- Upgrade Ruby all the way to 3.3.5
- Update various obsolete methods and gems
- Remove webdrivers requirement for system tests
- Reduce frequency of KeepProductIndexFresh job
- (See commit history for full change set)