### PR TITLE
Fix callbacks test and bump patch version [no ci]

### DIFF
--- a/core/lib/workarea/version.rb
+++ b/core/lib/workarea/version.rb
@@ -2,7 +2,7 @@ module Workarea
   module VERSION
     MAJOR = 3
     MINOR = 9
-    PATCH = 1
+    PATCH = 2
     STRING = [MAJOR, MINOR, PATCH].compact.join('.')
 
     module MONGODB

--- a/core/test/workers/sidekiq/callbacks_test.rb
+++ b/core/test/workers/sidekiq/callbacks_test.rb
@@ -93,7 +93,7 @@ module Sidekiq
       include Sidekiq::Worker
       include Sidekiq::CallbacksWorker
       sidekiq_options enqueue_on: {
-        Model => :save, with: -> { [id, changes] }
+        Model => :save, with: -> { [id.to_s, JSON.generate(changes)] }
       }
 
       def perform(*)
@@ -245,7 +245,7 @@ module Sidekiq
 
       args = CustomArgsWorker.jobs.last['args']
       assert_equal(args.first, model.id.to_s)
-      assert_equal(args.second, { 'name' => ['foo', 'bar'] })
+      assert_equal(JSON.parse(args.second), { 'name' => ['foo', 'bar'] })
     end
 
     def test_enabling_and_disabling


### PR DESCRIPTION
**Changes**
- Update Sidekiq::CallbacksTest to use safe args in the internal CustomArgsWorker class.
- Update test_custom_arguments to account for safe args.
- Bump patch version.