### PR TITLE
1685 - Fix Audit Log Bug

### DIFF
--- a/core/lib/workarea/ext/mongoid/audit_log_entry.rb
+++ b/core/lib/workarea/ext/mongoid/audit_log_entry.rb
@@ -17,7 +17,7 @@ module Mongoid
       end
 
       def model_name
-        if model_attributes['name'].present?
+        if model_attributes.present? && model_attributes['name'].present?
           model_attributes['name'][I18n.locale.to_s].presence || model_attributes['name']
         else
           'Not Found'

--- a/core/lib/workarea/ext/mongoid/audit_log_entry.rb
+++ b/core/lib/workarea/ext/mongoid/audit_log_entry.rb
@@ -17,6 +17,7 @@ module Mongoid
       end
 
       def model_name
+        raise "GOT HERE"
         if model_attributes['name'].present?
           model_name = model_attributes['name'][I18n.locale.to_s].presence || model_attributes['name']
         else
@@ -24,6 +25,7 @@ module Mongoid
         end
         puts "MODEL NAME =================================== "
         puts "#{model_name}\r\n\r\n"
+        model_name
       end
 
       def release

--- a/core/lib/workarea/ext/mongoid/audit_log_entry.rb
+++ b/core/lib/workarea/ext/mongoid/audit_log_entry.rb
@@ -17,15 +17,11 @@ module Mongoid
       end
 
       def model_name
-        raise "GOT HERE"
         if model_attributes['name'].present?
-          model_name = model_attributes['name'][I18n.locale.to_s].presence || model_attributes['name']
+          model_attributes['name'][I18n.locale.to_s].presence || model_attributes['name']
         else
-          model_name = model_attributes['name']
+          'Not Found'
         end
-        puts "MODEL NAME =================================== "
-        puts "#{model_name}\r\n\r\n"
-        model_name
       end
 
       def release

--- a/core/lib/workarea/ext/mongoid/audit_log_entry.rb
+++ b/core/lib/workarea/ext/mongoid/audit_log_entry.rb
@@ -17,8 +17,13 @@ module Mongoid
       end
 
       def model_name
-        model_attributes['name'][I18n.locale.to_s].presence ||
-          model_attributes['name']
+        if model_attributes['name'].present?
+          model_name = model_attributes['name'][I18n.locale.to_s].presence || model_attributes['name']
+        else
+          model_name = model_attributes['name']
+        end
+        puts "MODEL NAME =================================== "
+        puts "#{model_name}\r\n\r\n"
       end
 
       def release

--- a/core/lib/workarea/version.rb
+++ b/core/lib/workarea/version.rb
@@ -2,7 +2,7 @@ module Workarea
   module VERSION
     MAJOR = 3
     MINOR = 9
-    PATCH = 3
+    PATCH = 4
     STRING = [MAJOR, MINOR, PATCH].compact.join('.')
 
     module MONGODB

--- a/core/test/lib/workarea/ext/mongoid/audit_log_entry_test.rb
+++ b/core/test/lib/workarea/ext/mongoid/audit_log_entry_test.rb
@@ -64,5 +64,28 @@ module Mongoid
         end
       end
     end
+
+    def test_model_name
+      product = create_product(name: 'Foo')
+
+      entry = Entry.create!(
+        audited_id: product.id,
+        audited_type: product.class,
+        tracked_changes: { 'foo' => 'bar' }
+      )
+
+      assert_equal(entry.model_name, 'Not Found')
+
+      entry.model_attributes = {}
+      entry.model_attributes['active'] = true
+      entry.save!
+
+      assert_equal(entry.model_name, 'Not Found')
+
+      entry.model_attributes['name'] = 'Test Company'
+      entry.save!
+
+      assert_equal(entry.model_name, 'Test Company')
+    end
   end
 end

--- a/core/test/lib/workarea/ext/mongoid/audit_log_entry_test.rb
+++ b/core/test/lib/workarea/ext/mongoid/audit_log_entry_test.rb
@@ -63,29 +63,29 @@ module Mongoid
           refute(child_entry.restorable?)
         end
       end
-    end
 
-    def test_model_name
-      product = create_product(name: 'Foo')
+      def test_model_name
+        product = create_product(name: 'Foo')
 
-      entry = Entry.create!(
-        audited_id: product.id,
-        audited_type: product.class,
-        tracked_changes: { 'foo' => 'bar' }
-      )
+        entry = Entry.create!(
+          audited_id: product.id,
+          audited_type: product.class,
+          tracked_changes: { 'foo' => 'bar' }
+        )
 
-      assert_equal(entry.model_name, 'Not Found')
+        assert_equal(entry.model_name, 'Not Found')
 
-      entry.model_attributes = {}
-      entry.model_attributes['active'] = true
-      entry.save!
+        entry.model_attributes = {}
+        entry.model_attributes['active'] = true
+        entry.save!
 
-      assert_equal(entry.model_name, 'Not Found')
+        assert_equal(entry.model_name, 'Not Found')
 
-      entry.model_attributes['name'] = 'Test Company'
-      entry.save!
+        entry.model_attributes['name'] = 'Test Company'
+        entry.save!
 
-      assert_equal(entry.model_name, 'Test Company')
+        assert_equal(entry.model_name, 'Test Company')
+      end
     end
   end
 end


### PR DESCRIPTION
Jira Ticket: [1685](https://associatedpackagingtn.atlassian.net/browse/SPB-1685)

This ticket fixes the bug in the **Mongoid::AuditLog::Entry** class model_name method if either the model_attributes attribute is nil or the model_attributes['name'] value is a nil. The **NoMethodError: undefined method `[]' for nil (NoMethodError)** occurred when navigating to the admin dashboard (/admin) and a **Mongoid::AuditLog::Entry** entry either did not have any model_attributes (value of nil) or the model_attributes['name'] value was nil.

This PR also includes tests.
