### PR TITLE
Upgrade jQuery

### DIFF
--- a/core/lib/workarea/version.rb
+++ b/core/lib/workarea/version.rb
@@ -1,7 +1,7 @@
 module Workarea
   module VERSION
     MAJOR = 3
-    MINOR = 10
+    MINOR = 11
     PATCH = 0
     STRING = [MAJOR, MINOR, PATCH].compact.join('.')
 

--- a/core/workarea-core.gemspec
+++ b/core/workarea-core.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'i18n-js', '~> 3.8.0'
   s.add_dependency 'local_time', '~> 2.1.0'
   s.add_dependency 'lodash-rails', '~> 4.17.4'
-  s.add_dependency 'jquery-rails', '~> 4.4.0'
+  s.add_dependency 'jquery-rails', '~> 4.6.0'
   s.add_dependency 'jquery-ui-rails', '~> 6.0.1'
   s.add_dependency 'tooltipster-rails', '~> 4.2.0'
   s.add_dependency 'select2-rails', '~> 4.0.3'


### PR DESCRIPTION
**Jira**
- https://associatedpackagingtn.atlassian.net/browse/SPB-1631

**Changes**
- Upgrade the jquery-rails gem from 4.4.x to 4.6.x to get a more recent version of jQuery.
- Bump the Workarea version to 3.11.0.

If/when this gets merged, we'll tag a new version of the Workarea gem and pull that into SupplyBox.