### PR TITLE
1784 - Upgrade jquery-ui-rails gem to version 8

### DIFF
--- a/admin/app/assets/javascripts/workarea/admin/application.js.erb
+++ b/admin/app/assets/javascripts/workarea/admin/application.js.erb
@@ -15,7 +15,6 @@ window.feature.testAll();
     jquery_ujs
     jquery_ujs/replace
     jquery_ujs/insert
-    jquery-ui/core
     jquery-ui/widget
     jquery-ui/position
     jquery-ui/widgets/mouse

--- a/core/lib/workarea/version.rb
+++ b/core/lib/workarea/version.rb
@@ -1,7 +1,7 @@
 module Workarea
   module VERSION
     MAJOR = 3
-    MINOR = 12
+    MINOR = 13
     PATCH = 0
     STRING = [MAJOR, MINOR, PATCH].compact.join('.')
 

--- a/core/workarea-core.gemspec
+++ b/core/workarea-core.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'local_time', '~> 2.1.0'
   s.add_dependency 'lodash-rails', '~> 4.17.4'
   s.add_dependency 'jquery-rails', '~> 4.6.0'
-  s.add_dependency 'jquery-ui-rails', '~> 7.0.0'
+  s.add_dependency 'jquery-ui-rails', '~> 8.0.0'
   s.add_dependency 'tooltipster-rails', '~> 4.2.0'
   s.add_dependency 'select2-rails', '~> 4.0.3'
   s.add_dependency 'wysihtml-rails', '~> 0.6.0.beta2'

--- a/storefront/app/assets/javascripts/workarea/storefront/application.js.erb
+++ b/storefront/app/assets/javascripts/workarea/storefront/application.js.erb
@@ -17,7 +17,6 @@
     local-time
     lodash
     jquery3
-    jquery-ui/core
     jquery-ui/widget
     jquery-ui/position
     jquery-ui/widgets/mouse


### PR DESCRIPTION
Jira Ticke: [1784](https://associatedpackagingtn.atlassian.net/browse/SPB-1784)

This PR upgrades the jquery-ui-rails gem to version 8 and bumps up the minor version from 12 to 13.